### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Example json payload:
           "dest": "/home/pranjal/projects/osl/syncedup_temp/", # "/data/ftp/.1/",
         }
 
-`id` paramter is compulsary.
+`id` paramter is compulsory.
 The `project` parameter is optional. If this parameter is update the new id will also change and
 automatically set as per the name of the project.
 


### PR DESCRIPTION
@pramttl, I've corrected a typographical error in the documentation of the [mirror-sync-api](https://github.com/pramttl/mirror-sync-api) project. Specifically, I've changed compulsary to compulsory. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
